### PR TITLE
Delete training program

### DIFF
--- a/BangazonWorkforceManagement/Models/TrainingProgram.cs
+++ b/BangazonWorkforceManagement/Models/TrainingProgram.cs
@@ -24,5 +24,12 @@ namespace BangazonAPI.Models
 
         public List<Employee> Attendees { get; set; }
 
+        public bool IsCancelable { get
+            {
+                return DateTime.Compare(StartDate, DateTime.Today) > 0;
+            }
+
+        }
+
     }
 }

--- a/BangazonWorkforceManagement/Views/TrainingPrograms/Delete.cshtml
+++ b/BangazonWorkforceManagement/Views/TrainingPrograms/Delete.cshtml
@@ -1,0 +1,56 @@
+﻿@model BangazonAPI.Models.TrainingProgram
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<h1>Delete</h1>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>TrainingProgram</h4>
+    <hr />
+    <dl class="row">
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Id)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Id)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.StartDate)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.StartDate)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.EndDate)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.EndDate)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.MaxAttendees)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.MaxAttendees)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.IsCancelable)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.IsCancelable)
+        </dd>
+    </dl>
+    
+    <form asp-action="Delete">
+        <input type="submit" value="Delete" class="btn btn-danger" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+</div>

--- a/BangazonWorkforceManagement/Views/TrainingPrograms/Index.cshtml
+++ b/BangazonWorkforceManagement/Views/TrainingPrograms/Index.cshtml
@@ -51,7 +51,7 @@
             <td>
                 @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
                 @Html.ActionLink("Details", "Details", new { id = item.Id }) |
-                @Html.ActionLink("Delete", "Delete", new { id = item.Id  })
+                @if (item.IsCancelable) { @Html.ActionLink("Delete", "Delete", new { id = item.Id }); }
             </td>
         </tr>
 }


### PR DESCRIPTION
# Description

Provides users the ability to delete training programs that have not yet started.

Fixes #12 

## Type of change

Please delete options that are not relevant.


- [X] New feature (non-breaking change which adds functionality)


# Testing Instructions

Navigate to TrainingPrograms.  Training programs that have a StartDate in the past will not have a Delete button.  

If needed, create a training program with a future start date, then you should be able to delete it.

Note that deleting a training program will also remove related EmployeeTraining entries.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
