### PR TITLE
Completed filtering training programs

### DIFF
--- a/BangazonWorkforceManagement/Controllers/TrainingProgramsController.cs
+++ b/BangazonWorkforceManagement/Controllers/TrainingProgramsController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,7 +33,16 @@ namespace BangazonWorkforceManagement.Controllers
         // GET: TrainingPrograms
         public async Task<IActionResult> Index()
         {
-            var progs = await GetTrainingPrograms();
+            var active = true;
+            var progs = await GetTrainingPrograms(active);
+            return View(progs);
+        }
+
+        //  GET: Train
+        public async Task<IActionResult> Archive()
+        {
+            var active = false;
+            var progs = await GetTrainingPrograms(active);
             return View(progs);
         }
 
@@ -149,7 +159,7 @@ namespace BangazonWorkforceManagement.Controllers
             }
         }
 
-        private async Task<List<TrainingProgram>> GetTrainingPrograms(string filterText = "")
+        private async Task<List<TrainingProgram>> GetTrainingPrograms(bool future = true)
         {
             var progs = new List<TrainingProgram>();
             using (SqlConnection conn = Connection)
@@ -158,7 +168,10 @@ namespace BangazonWorkforceManagement.Controllers
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT Id, [Name], StartDate, EndDate, MaxAttendees FROM TrainingProgram ";
-                    cmd.CommandText += filterText;  
+                    cmd.CommandText += "WHERE StartDate ";
+                    cmd.CommandText += future ? ">" : " <= ";
+                    cmd.CommandText += " @compareDate";
+                    cmd.Parameters.Add(new SqlParameter("@compareDate", SqlDbType.DateTime) { Value = DateTime.Today });
 
                     var reader = cmd.ExecuteReader();
 

--- a/BangazonWorkforceManagement/Views/TrainingPrograms/Archive.cshtml
+++ b/BangazonWorkforceManagement/Views/TrainingPrograms/Archive.cshtml
@@ -1,0 +1,57 @@
+﻿@model IEnumerable<BangazonAPI.Models.TrainingProgram>
+
+@{
+    ViewData["Title"] = "Archive";
+}
+
+<h1>Training Program Archive</h1>
+
+<p>
+    <a asp-action="Index">Back to Active Training Programs</a>
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.Id)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.StartDate)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.EndDate)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.MaxAttendees)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.Id)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.StartDate)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.EndDate)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.MaxAttendees)
+            </td>
+            <td>
+                @Html.ActionLink("Details", "Details", new { /* id=item.PrimaryKey */ })
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/BangazonWorkforceManagement/Views/TrainingPrograms/Index.cshtml
+++ b/BangazonWorkforceManagement/Views/TrainingPrograms/Index.cshtml
@@ -1,10 +1,10 @@
 ﻿@model IEnumerable<BangazonAPI.Models.TrainingProgram>
 
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "Training programs";
 }
 
-<h1>Index</h1>
+<h1>Training Programs</h1>
 
 <p>
     <a asp-action="Create">Create New</a>
@@ -31,29 +31,35 @@
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Id)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Name)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.StartDate)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.EndDate)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.MaxAttendees)
-            </td>
-            <td>
-                @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
-                @Html.ActionLink("Details", "Details", new { id = item.Id }) |
-                @if (item.IsCancelable) { @Html.ActionLink("Delete", "Delete", new { id = item.Id }); }
-            </td>
-        </tr>
-}
+        @foreach (var item in Model)
+        {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Id)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Name)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.StartDate)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.EndDate)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.MaxAttendees)
+                </td>
+                <td>
+                    @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
+                    @Html.ActionLink("Details", "Details", new { id = item.Id }) |
+                    @if (item.IsCancelable)
+                    {@Html.ActionLink("Delete", "Delete", new { id = item.Id });
+                }
+                </td>
+            </tr>
+        }
     </tbody>
 </table>
+<p>
+    <a asp-action="Archive">View Past Training Programs</a>
+</p>


### PR DESCRIPTION
# Description

Default Training Program view now shows only training programs with a `StartDate` in the future.  Select "View Past Training programs to display a list of training programs that have already started.

Fixes #16 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Testing Instructions

Navigate to Training programs.  Verify that no training programs with a StartDate in the past are viewable.
Select "View Past Training Programs".
You should now see only training programs with a Start date today or earlier.  You should also *NOT* see edit or delete controls.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
